### PR TITLE
Fix entrypoint pid path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Remove a potentially pre-existing server.pid for Rails.
-rm -f /better_together/tmp/pids/server.pid
+rm -f /bt/tmp/pids/server.pid
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"


### PR DESCRIPTION
## Summary
- fix incorrect path to `server.pid` in `entrypoint.sh`

## Testing
- `bundle exec rspec --format doc` *(fails: ruby not available)*

------
https://chatgpt.com/codex/tasks/task_e_6886d3f8396c8321926879de6aea87bc