### PR TITLE
chore(db): install missing better_together migrations

### DIFF
--- a/db/migrate/20260331180908_seed_platform_member_role_before_host_backfill.better_together.rb
+++ b/db/migrate/20260331180908_seed_platform_member_role_before_host_backfill.better_together.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# This migration comes from better_together (originally 20260320235959)
+class SeedPlatformMemberRoleBeforeHostBackfill < ActiveRecord::Migration[7.2]
+  class Role < ActiveRecord::Base
+    self.table_name = 'better_together_roles'
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ResourcePermission < ActiveRecord::Base
+    self.table_name = 'better_together_resource_permissions'
+  end
+
+  class RoleResourcePermission < ActiveRecord::Base
+    self.table_name = 'better_together_role_resource_permissions'
+  end
+
+  class MobilityStringTranslation < ActiveRecord::Base
+    self.table_name = 'mobility_string_translations'
+  end
+
+  class MobilityTextTranslation < ActiveRecord::Base
+    self.table_name = 'mobility_text_translations'
+  end
+
+  class FriendlyIdSlug < ActiveRecord::Base
+    self.table_name = 'friendly_id_slugs'
+  end
+
+  def up
+    role = Role.find_or_initialize_by(identifier: 'platform_member')
+    role.assign_attributes(
+      protected: true,
+      resource_type: 'BetterTogether::Platform',
+      type: 'BetterTogether::Role'
+    )
+    role.position ||= next_position_for(Role, 'BetterTogether::Platform')
+    role.save! if role.changed?
+    upsert_slug!(role, 'BetterTogether::Role')
+
+    upsert_role_translation!(
+      MobilityStringTranslation,
+      role.id,
+      'name',
+      'Platform Member'
+    )
+    upsert_role_translation!(
+      MobilityTextTranslation,
+      role.id,
+      'description',
+      'Basic platform role for signed-in members who can access platform information without platform management authority.'
+    )
+
+    permission = ResourcePermission.find_or_initialize_by(identifier: 'read_platform')
+    permission.assign_attributes(
+      action: 'read',
+      target: 'platform',
+      resource_type: 'BetterTogether::Platform',
+      protected: true,
+      position: 1
+    )
+    permission.save! if permission.changed?
+    upsert_slug!(permission, 'BetterTogether::ResourcePermission')
+
+    RoleResourcePermission.find_or_create_by!(
+      role_id: role.id,
+      resource_permission_id: permission.id
+    )
+
+    activate_existing_host_platform_managers!
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def next_position_for(model_class, resource_type)
+    max_position = model_class.where(resource_type: resource_type).maximum(:position)
+    max_position ? max_position + 1 : 0
+  end
+
+  def upsert_role_translation!(translation_class, role_id, key, value)
+    translation = translation_class.find_or_initialize_by(
+      locale: I18n.default_locale.to_s,
+      key:,
+      translatable_type: 'BetterTogether::Role',
+      translatable_id: role_id
+    )
+    translation.value = value
+    translation.save! if translation.changed?
+  end
+
+  def upsert_slug!(record, sluggable_type)
+    slug = record.identifier.to_s.parameterize
+    upsert_mobility_slug!(sluggable_type, record.id, slug)
+
+    friendly_slug = FriendlyIdSlug.find_or_initialize_by(
+      sluggable_type:,
+      sluggable_id: record.id,
+      locale: I18n.default_locale.to_s
+    )
+    friendly_slug.slug = slug
+    friendly_slug.scope = nil
+    friendly_slug.save! if friendly_slug.changed?
+  end
+
+  def upsert_mobility_slug!(translatable_type, translatable_id, slug)
+    translation = MobilityStringTranslation.find_or_initialize_by(
+      locale: I18n.default_locale.to_s,
+      key: 'slug',
+      translatable_type:,
+      translatable_id:
+    )
+    translation.value = slug
+    translation.save! if translation.changed?
+  end
+
+  def activate_existing_host_platform_managers!
+    execute <<~SQL.squish
+      UPDATE better_together_person_platform_memberships memberships
+      SET    status = 'active',
+             updated_at = NOW()
+      FROM   better_together_roles roles,
+             better_together_platforms platforms
+      WHERE  memberships.role_id = roles.id
+        AND  memberships.joinable_id = platforms.id
+        AND  platforms.host = TRUE
+        AND  memberships.status = 'pending'
+        AND  roles.identifier IN ('platform_steward', 'platform_manager')
+    SQL
+  end
+end

--- a/db/migrate/20260331180909_add_platform_and_logged_in_to_metrics.better_together.rb
+++ b/db/migrate/20260331180909_add_platform_and_logged_in_to_metrics.better_together.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# This migration comes from better_together (originally 20260330172000)
+class AddPlatformAndLoggedInToMetrics < ActiveRecord::Migration[7.2]
+  class Platform < ActiveRecord::Base
+    self.table_name = 'better_together_platforms'
+  end
+
+  RAW_METRIC_TABLES = %i[
+    better_together_metrics_page_views
+    better_together_metrics_link_clicks
+    better_together_metrics_shares
+    better_together_metrics_downloads
+    better_together_metrics_search_queries
+  ].freeze
+
+  REPORT_TABLES = %i[
+    better_together_metrics_page_view_reports
+    better_together_metrics_link_click_reports
+  ].freeze
+
+  def up
+    RAW_METRIC_TABLES.each do |table|
+      add_reference table, :platform, type: :uuid, foreign_key: { to_table: :better_together_platforms }, index: true
+      add_column table, :logged_in, :boolean, default: false, null: false
+    end
+
+    REPORT_TABLES.each do |table|
+      add_reference table, :platform, type: :uuid, foreign_key: { to_table: :better_together_platforms }, index: true
+    end
+
+    backfill_platform_ids!
+
+    (RAW_METRIC_TABLES + REPORT_TABLES).each do |table|
+      change_column_null table, :platform_id, false
+    end
+  end
+
+  def down
+    (RAW_METRIC_TABLES + REPORT_TABLES).reverse_each do |table|
+      remove_reference table, :platform, foreign_key: { to_table: :better_together_platforms }, index: true
+    end
+
+    RAW_METRIC_TABLES.reverse_each do |table|
+      remove_column table, :logged_in
+    end
+  end
+
+  private
+
+  def backfill_platform_ids!
+    host_platform_id = Platform.where(host: true).pick(:id)
+
+    if host_platform_id.blank?
+      return unless metric_or_report_rows_exist?
+
+      raise ActiveRecord::MigrationError, 'Cannot backfill metrics platform_id without a host platform'
+    end
+
+    (RAW_METRIC_TABLES + REPORT_TABLES).each do |table|
+      execute <<~SQL.squish
+        UPDATE #{quote_table_name(table)}
+        SET platform_id = #{quote(host_platform_id)}
+        WHERE platform_id IS NULL
+      SQL
+    end
+  end
+
+  def metric_or_report_rows_exist?
+    (RAW_METRIC_TABLES + REPORT_TABLES).any? do |table|
+      select_value("SELECT 1 FROM #{quote_table_name(table)} LIMIT 1").present?
+    end
+  end
+end

--- a/db/migrate/20260331180910_create_person_data_exports_and_deletion_requests.better_together.rb
+++ b/db/migrate/20260331180910_create_person_data_exports_and_deletion_requests.better_together.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This migration comes from better_together (originally 20260330194500)
+class CreatePersonDataExportsAndDeletionRequests < ActiveRecord::Migration[7.2]
+  def change
+    create_table :better_together_person_data_exports, id: :uuid do |t|
+      t.references :person, null: false, type: :uuid, foreign_key: { to_table: :better_together_people }
+      t.string :status, null: false, default: 'pending'
+      t.string :format, null: false, default: 'json'
+      t.datetime :requested_at, null: false
+      t.datetime :started_at
+      t.datetime :completed_at
+      t.text :error_message
+      t.timestamps
+    end
+
+    add_index :better_together_person_data_exports, %i[person_id requested_at], name: 'idx_bt_person_data_exports_person_requested'
+
+    create_table :better_together_person_deletion_requests, id: :uuid do |t|
+      t.references :person, null: false, type: :uuid, foreign_key: { to_table: :better_together_people }
+      t.references :reviewed_by, null: true, type: :uuid, foreign_key: { to_table: :better_together_people }
+      t.string :status, null: false, default: 'pending'
+      t.datetime :requested_at, null: false
+      t.datetime :resolved_at
+      t.text :requested_reason
+      t.text :reviewer_notes
+      t.timestamps
+    end
+
+    add_index :better_together_person_deletion_requests, %i[person_id status], name: 'idx_bt_person_deletion_requests_person_status'
+  end
+end

--- a/db/migrate/20260331180911_add_acceptance_audit_fields_to_agreement_participants.better_together.rb
+++ b/db/migrate/20260331180911_add_acceptance_audit_fields_to_agreement_participants.better_together.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# This migration comes from better_together (originally 20260330203000)
+class AddAcceptanceAuditFieldsToAgreementParticipants < ActiveRecord::Migration[7.1]
+  def up
+    return unless table_exists?(:better_together_agreement_participants)
+
+    add_acceptance_audit_columns
+    backfill_acceptance_audit_fields
+    enforce_acceptance_audit_constraints
+  end
+
+  def down
+    return unless table_exists?(:better_together_agreement_participants)
+
+    remove_acceptance_audit_columns
+  end
+
+  private
+
+  def add_acceptance_audit_columns
+    add_column_if_missing :acceptance_method, :string
+    add_column_if_missing :agreement_identifier_snapshot, :string
+    add_column_if_missing :agreement_title_snapshot, :string
+    add_column_if_missing :agreement_updated_at_snapshot, :datetime
+    add_column_if_missing :agreement_content_digest, :string
+    add_column_if_missing :audit_context, :jsonb, default: {}, null: false
+  end
+
+  def backfill_acceptance_audit_fields
+    BetterTogether::AgreementParticipant.reset_column_information
+    BetterTogether::Agreement.reset_column_information
+
+    say_with_time 'Backfilling agreement acceptance audit fields' do
+      BetterTogether::AgreementParticipant.includes(:agreement).find_each do |participant|
+        agreement = participant.agreement
+        next unless agreement
+
+        participant.update_columns(backfilled_acceptance_attributes(participant, agreement))
+      end
+    end
+  end
+
+  def backfilled_acceptance_attributes(participant, agreement)
+    {
+      acceptance_method: participant[:acceptance_method].presence || 'legacy',
+      agreement_identifier_snapshot: participant[:agreement_identifier_snapshot].presence || agreement.identifier.to_s,
+      agreement_title_snapshot: participant[:agreement_title_snapshot].presence || agreement.title.to_s,
+      agreement_updated_at_snapshot: participant[:agreement_updated_at_snapshot] || participant_snapshot_time(participant, agreement),
+      agreement_content_digest: participant[:agreement_content_digest].presence || agreement.acceptance_content_digest,
+      audit_context: (participant[:audit_context].presence || {}).merge('backfilled' => true)
+    }
+  end
+
+  def participant_snapshot_time(participant, agreement)
+    agreement.updated_at || participant.accepted_at || participant.created_at || Time.current
+  end
+
+  def enforce_acceptance_audit_constraints
+    change_column_default :better_together_agreement_participants, :acceptance_method, 'agreement_review'
+
+    %i[
+      acceptance_method
+      agreement_identifier_snapshot
+      agreement_title_snapshot
+      agreement_updated_at_snapshot
+      agreement_content_digest
+    ].each do |column_name|
+      change_column_null :better_together_agreement_participants, column_name, false
+    end
+  end
+
+  def remove_acceptance_audit_columns
+    %i[
+      audit_context
+      agreement_content_digest
+      agreement_updated_at_snapshot
+      agreement_title_snapshot
+      agreement_identifier_snapshot
+      acceptance_method
+    ].each do |column_name|
+      remove_column_if_present(column_name)
+    end
+  end
+
+  def add_column_if_missing(column_name, type, **)
+    return if column_exists?(:better_together_agreement_participants, column_name)
+
+    add_column :better_together_agreement_participants, column_name, type, **
+  end
+
+  def remove_column_if_present(column_name)
+    return unless column_exists?(:better_together_agreement_participants, column_name)
+
+    remove_column :better_together_agreement_participants, column_name
+  end
+end


### PR DESCRIPTION
## Summary
- install the missing `better_together` engine migrations into `better-together-rails` using the Rails migration installer
- restore the metrics schema expected by the current CE pin so `/en/host/metrics/reports` and metrics jobs stop hitting missing `platform_id` columns
- bring the host app migration set back in sync with the pinned engine revision

## Testing
- `bundle exec rails railties:install:migrations FROM=better_together`
- `ruby -c db/migrate/20260331180908_seed_platform_member_role_before_host_backfill.better_together.rb`
- `ruby -c db/migrate/20260331180909_add_platform_and_logged_in_to_metrics.better_together.rb`
- `ruby -c db/migrate/20260331180910_create_person_data_exports_and_deletion_requests.better_together.rb`
- `ruby -c db/migrate/20260331180911_add_acceptance_audit_fields_to_agreement_participants.better_together.rb`
- production Dokku release ran `bundle exec rails db:migrate` successfully and applied the four missing migrations

## Notes
- repo pre-commit hook could not run locally because the Docker harness hit `all predefined address pools have been fully subnetted`
